### PR TITLE
MAINT: add env file for QIIME 2 2026.1

### DIFF
--- a/environment-files/q2-gunc-qiime2-tiny-2026.1.yml
+++ b/environment-files/q2-gunc-qiime2-tiny-2026.1.yml
@@ -13,4 +13,4 @@ dependencies:
   - gunc
   - pip
   - pip:
-     - "q2-gunc@git+https://github.com/bokulich-lab/q2-gunc.git"
+     - q2-gunc@git+https://github.com/bokulich-lab/q2-gunc.git@2026.1.0

--- a/environment-files/q2-gunc-qiime2-tiny-2026.1.yml
+++ b/environment-files/q2-gunc-qiime2-tiny-2026.1.yml
@@ -1,0 +1,16 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2
+  - q2cli
+  - q2templates
+  - q2-types
+  - q2-metadata
+  - beautifulsoup4
+  - cssutils
+  - gunc
+  - pip
+  - pip:
+     - "q2-gunc@git+https://github.com/bokulich-lab/q2-gunc.git"


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2026.1.

Generated from the latest env file in 'environment-files/' by updating the release token.