### PR TITLE
MAINT: migrate Dockerfile to use micromamba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ ENV PATH=/opt/conda/envs/${PLUGIN_NAME}/bin:$PATH \
 WORKDIR /home/qiime2
 COPY environment.yml .
 
-RUN apt-get update && apt-get install -y --no-install-recommends wget procps make \
+RUN apt-get update && apt-get install -y --no-install-recommends wget procps make git \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM continuumio/miniconda3:latest AS base
+FROM mambaorg/micromamba:2.4.0 AS base
 
+USER root
+
+ARG ENVIRONMENT
 ARG PLUGIN_NAME
 
-ENV PLUGIN_NAME=$PLUGIN_NAME
+ENV PLUGIN_NAME=$PLUGIN_NAME \
+    ENV_NAME=$PLUGIN_NAME
 ENV PATH=/opt/conda/envs/${PLUGIN_NAME}/bin:$PATH \
     LC_ALL=C.UTF-8 LANG=C.UTF-8 \
     MPLBACKEND=agg \
@@ -17,19 +21,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget procps mak
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN conda update -qy conda \
-    && conda install -c conda-forge -qy mamba \
-    && mamba env create -n ${PLUGIN_NAME} --file environment.yml \
-    && mamba clean --all --yes \
+RUN micromamba create --yes -n ${PLUGIN_NAME} --file environment.yml \
+    && micromamba clean --all --yes \
     && chmod -R a+rwx /opt/conda
 
 COPY . ./plugin
-RUN mamba run -n ${PLUGIN_NAME} pip install ./plugin
+RUN micromamba run -n ${PLUGIN_NAME} pip install ./plugin
 
-RUN /bin/bash -c "source activate ${PLUGIN_NAME}"
 ENV CONDA_PREFIX=/opt/conda/envs/${PLUGIN_NAME}/
-RUN mamba run -n ${PLUGIN_NAME} qiime dev refresh-cache
-RUN echo "source activate ${PLUGIN_NAME}" >> $HOME/.bashrc
+RUN micromamba run -n ${PLUGIN_NAME} qiime dev refresh-cache
+RUN echo 'eval "$(micromamba shell hook --shell bash)"' >> $HOME/.bashrc \
+    && echo "micromamba activate ${PLUGIN_NAME}" >> $HOME/.bashrc
 RUN echo "source tab-qiime" >> $HOME/.bashrc
 
 
@@ -37,8 +39,9 @@ FROM base AS test
 
 LABEL quay.expires-after=4w
 
-RUN mamba run -n ${PLUGIN_NAME} pip install pytest pytest-cov coverage parameterized pytest-xdist
-CMD mamba run -n ${PLUGIN_NAME} make -f ./plugin/Makefile test-cov
+RUN micromamba run -n ${PLUGIN_NAME} pip install pytest pytest-cov coverage parameterized pytest-xdist
+CMD micromamba run -n ${PLUGIN_NAME} make -f ./plugin/Makefile test-cov
+RUN chmod -R a+rwx /home/qiime2
 
 FROM base AS prod
 

--- a/environment-files/q2-gunc-rachis-tiny-2026.7.yml
+++ b/environment-files/q2-gunc-rachis-tiny-2026.7.yml
@@ -1,0 +1,12 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.7/tiny/released
+- conda-forge
+- bioconda
+dependencies:
+  - rachis-tiny
+  - beautifulsoup4
+  - cssutils
+  - gunc
+  - pip
+  - pip:
+     - q2-gunc@git+https://github.com/bokulich-lab/q2-gunc.git@2026.7.0


### PR DESCRIPTION
<!-- PR guidance and examples: https://github.com/rachis-org/governance/blob/main/pr_template_guidelines.md -->
<!-- rachis Generative AI Policy: https://github.com/rachis-org/governance/blob/main/ai_policy.md -->

# Description
<!-- REQUIRED: Briefly describe this PR, or link the issue it closes. -->
Migrates the Dockerfile to use `mambaorg/micromamba` as the base image instead of the legacy conda/mamba-based setup.

# AI Disclosure
<!-- REQUIRED: Check exactly one option. -->

- [ ] NO AI USED.
- [x] AI USED.


# AI Usage Details
<!-- REQUIRED if 'AI USED' is checked. This section can be deleted if 'NO AI USED' is checked. -->
Claude Sonnet 5 was used to open this PR across repositories.